### PR TITLE
Azure pipelines CI build and publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,6 @@ steps:
 
 # Build and run tests
 
-- script: dotnet restore
-  workingDirectory: 'src'
-  displayName: 'dotnet restore'
-
 - script: dotnet build --configuration $(buildConfiguration)
   workingDirectory: 'src'
   displayName: 'dotnet build $(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,17 +30,8 @@ steps:
 
 # Package and push Nuget
 
-- task: NuGetCommand@2
-  displayName: 'nuget pack'
-  inputs:
-    command: pack
-    packagesToPack: '**/DataWorx.Core.csproj'
-    versioningScheme: byBuildNumber
-    configuration: '$(buildConfiguration)'
-    packDestination: '$(Build.ArtifactStagingDirectory)'
+- script: dotnet pack src/DataWorx.Core/DataWorx.Core.csproj -o $(Build.ArtifactStagingDirectory) -c $(buildConfiguration) -p:PackageVersion=$(Build.BuildNumber)
+  displayName: 'dotnet pack'
 
-- script: nuget setApiKey $(nugetApiKey)  # Note this variable will need to be set in Azure DevOps
-  displayName: 'nuget setApiKey'
-
-- script: nuget push $(Build.ArtifactStagingDirectory)/**/*.nupkg -Source https://api.nuget.org/v3/index.json
-  displayName: 'nuget push'
+- script: dotnet nuget push $(Build.ArtifactStagingDirectory)/**/*.nupkg -Source https://api.nuget.org/v3/index.json -k $(nugetApiKey)
+  displayName: 'dotnet nuget push'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,5 +33,5 @@ steps:
 - script: dotnet pack src/DataWorx.Core/DataWorx.Core.csproj -o $(Build.ArtifactStagingDirectory) -c $(buildConfiguration) -p:PackageVersion=$(Build.BuildNumber)
   displayName: 'dotnet pack'
 
-- script: dotnet nuget push $(Build.ArtifactStagingDirectory)/**/*.nupkg -Source https://api.nuget.org/v3/index.json -k $(nugetApiKey)
+- script: dotnet nuget push $(Build.ArtifactStagingDirectory)/**/*.nupkg -s https://api.nuget.org/v3/index.json -k $(nugetApiKey)
   displayName: 'dotnet nuget push'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,9 +39,8 @@ steps:
     configuration: '$(buildConfiguration)'
     packDestination: '$(Build.ArtifactStagingDirectory)'
 
-- task: NuGetCommand@2
-  inputs:
-    command: push
-    nuGetFeedType: external
-    publishFeedCredentials: 'NugetPublishConnection' # Note this will need to be set up in Azure DevOps
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+- script: nuget setApiKey $(nugetApiKey)  # Note this variable will need to be set in Azure DevOps
+  displayName: 'nuget setApiKey'
+
+- script: nuget push $(Build.ArtifactStagingDirectory)/**/*.nupkg -Source https://api.nuget.org/v3/index.json
+  displayName: 'nuget push'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # CI build and push to Nuget
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
-name: 1.0.$(Rev:..r)
+name: 1.0$(Rev:.r)
 
 pool:
   vmImage: 'Ubuntu 16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,47 @@
+# CI build and push to Nuget
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+name: 1.0.$(Rev:..r)
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+
+# Build and run tests
+
+- script: dotnet restore
+  workingDirectory: 'src'
+  displayName: 'dotnet restore'
+
+- script: dotnet build --configuration $(buildConfiguration)
+  workingDirectory: 'src'
+  displayName: 'dotnet build $(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test $(buildConfiguration)'
+  inputs:
+    command: test
+    projects: '**/*.Tests.csproj'
+    arguments: '--configuration $(buildConfiguration)'
+
+# Package and push Nuget
+
+- task: NuGetCommand@2
+  displayName: 'nuget pack'
+  inputs:
+    command: pack
+    packagesToPack: '**/DataWorx.Core.csproj'
+    versioningScheme: byBuildNumber
+    configuration: '$(buildConfiguration)'
+    packDestination: '$(Build.ArtifactStagingDirectory)'
+
+- task: NuGetCommand@2
+  inputs:
+    command: push
+    nuGetFeedType: external
+    publishFeedCredentials: 'NugetPublishConnection' # Note this will need to be set up in Azure DevOps
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'


### PR DESCRIPTION
Adds a YAML CI build definition for [Azure Pipelines](https://dev.azure.com) that builds, runs tests, then publishes to nuget.org.

This build definition will need an additional variable (`nugetApiKey`) to succeed. I'd strongly recommend setting that as a secure variable (click on the lock)!
![image](https://user-images.githubusercontent.com/1887732/46931130-82ebdc00-d095-11e8-98ab-ce52d7714204.png)

You can get an API key by following the instructions [on this page](https://docs.microsoft.com/en-us/nuget/create-packages/publish-a-package#create-api-keys).